### PR TITLE
add partners_cooperation page

### DIFF
--- a/_posts/partners_cooperation.markdown
+++ b/_posts/partners_cooperation.markdown
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Event Partners
+date:   2018-03-26 21:15:45 +0100
+categories: collaborations
+---
+### Cooperation Partners
+<img src="/img/panda-wtm.png" alt="Logo PANDA"/></br>
+[we-are-panda.com](https://www.we-are-panda.com "PANDA") 


### PR DESCRIPTION
There will be two pages, one for cooperation partners, where we support each other by sharing events and spreading the word and the other one for event partners 